### PR TITLE
Add no-analytics flag

### DIFF
--- a/start-meilisearch.sh
+++ b/start-meilisearch.sh
@@ -11,7 +11,7 @@ if [ -z "$MEILISEARCH_API_KEY" ]; then
   echo "  - version [$MEILISEARCH_VERSION]"
   echo ""
 
-  docker run --name meilisearch --publish $MEILISEARCH_PORT:$MEILISEARCH_PORT --detach --volume "$(pwd)/data.ms:/data.ms" getmeili/meilisearch:$MEILISEARCH_VERSION
+  docker run --name meilisearch --publish $MEILISEARCH_PORT:$MEILISEARCH_PORT --detach --volume "$(pwd)/data.ms:/data.ms" getmeili/meilisearch:$MEILISEARCH_VERSION --no-analytics=true
   echo "::endgroup::"
 
   return
@@ -23,5 +23,5 @@ echo "  - version [$MEILISEARCH_VERSION]"
 echo "  - api key [$MEILISEARCH_API_KEY]"
 echo ""
 
-docker run --name meilisearch --publish $MEILISEARCH_PORT:$MEILISEARCH_PORT -e MEILI_MASTER_KEY="$MEILISEARCH_API_KEY" --detach --volume "$(pwd)/data.ms:/data.ms" getmeili/meilisearch:$MEILISEARCH_VERSION
+docker run --name meilisearch --publish $MEILISEARCH_PORT:$MEILISEARCH_PORT -e MEILI_MASTER_KEY="$MEILISEARCH_API_KEY" --detach --volume "$(pwd)/data.ms:/data.ms" getmeili/meilisearch:$MEILISEARCH_VERSION --no-analytics=true
 echo "::endgroup::"


### PR DESCRIPTION
I would suggest adding the `--no-analytics` flag so CI runs don't skew their analytics results. If you agree and merge this note that when v0.26.0 is released the `--no-analytics=true` flag has been changed to just `--no-analytics`.